### PR TITLE
Fix malloc() and free() on some platforms in src/Actions/*

### DIFF
--- a/h/Action.h
+++ b/h/Action.h
@@ -9,6 +9,8 @@
 #include <string>
 
 
+#include <stdlib.h> // malloc() and free() on some systems
+
 using std::shared_ptr;
 using std::unique_ptr;
 using std::to_string;


### PR DESCRIPTION
On some platforms (macOS/clang is the main offender), `malloc()` and `free()` are not included in some files under `src/Actions`. I have fixed the problem by including `stdlib.h` in `h/Action.h`.

If you want, I can move the fix to another file, or put it in each broken `src/Actions/*.cpp` file (though I'd rather put it in a header).